### PR TITLE
fix(workflow): correct shell syntax error in git configuration step

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -151,7 +151,7 @@ jobs:
           git config --local user.name "Kubit Release Bot"
 
           # Set up authentication for push operations
-          if [ -n "${{ secrets.RELEASE_TOKEN }}" ]; thenn
+          if [ -n "${{ secrets.RELEASE_TOKEN }}" ]; then
             echo "🔐 Using RELEASE_TOKEN with branch protection bypass permissions"
             git remote set-url origin https://x-access-token:${{ secrets.RELEASE_TOKEN }}@github.com/${{ github.repository }}.git
           else


### PR DESCRIPTION
Fix shell syntax error in auto-publish workflow git configuration

- Fix typo: change 'thenn' to 'then' in conditional statement
- Correct shell script syntax for RELEASE_TOKEN authentication setup
- Maintain proper conditional logic for branch protection bypass

This resolves the "syntax error near unexpected token 'else'" error
that was preventing the workflow from executing the git configuration step.