### PR TITLE
feat: add React 19 support with backward compatibility for React 18.3+

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,13 @@
   "engines": {
     "node": "22.x"
   },
-  "packageManager": "pnpm@10.28.1",
+  "packageManager": "pnpm@10.29.3",
+  "pnpm": {
+    "overrides": {
+      "eslint-plugin-react-hooks": "7.1.0-canary-272441a9-20260209",
+      "zod-validation-error": "^3.4.0"
+    }
+  },
   "scripts": {
     "dev": "turbo run dev --filter=@kubit-ui-web/storybook",
     "dev:components": "turbo run dev --filter=@kubit-ui-web/react-components",
@@ -78,7 +84,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.8",
-    "turbo": "^2.8.1"
+    "turbo": "^2.8.7"
   },
   "bugs": {
     "url": "https://github.com/kubit-ui/kubit-react-components/issues",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -166,8 +166,8 @@
     "prerelease": "pnpm validate && pnpm test"
   },
   "peerDependencies": {
-    "react": ">=17.0.0 || >=18.3.1",
-    "react-dom": ">=17.0.0 || >=18.3.1"
+    "react": "^18.3.0 || ^19.0.0",
+    "react-dom": "^18.3.0 || ^19.0.0"
   },
   "dependencies": {
     "@floating-ui/dom": "^1.7.5"
@@ -180,8 +180,8 @@
     "@testing-library/user-event": "^14.6.1",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@types/node": "^25.2.3",
-    "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@types/testing-library__jest-dom": "^6.0.0",
     "@vitejs/plugin-react": "^5.1.4",
     "@vitest/coverage-v8": "^4.0.18",
@@ -193,8 +193,8 @@
     "html-validate": "^10.7.0",
     "jsdom": "^28.0.0",
     "prettier": "^3.8.1",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.55.0",
     "vite": "8.0.0-beta.10",

--- a/packages/components/src/components/accordion/hooks/useAccordionContentOverflow.ts
+++ b/packages/components/src/components/accordion/hooks/useAccordionContentOverflow.ts
@@ -1,7 +1,7 @@
 import { type RefObject, useEffect, useRef } from 'react';
 
 interface UseAccordionContentOverflowParamsType {
-  ref: RefObject<HTMLDivElement>;
+  ref: RefObject<HTMLDivElement | null>;
   expanded: boolean;
 }
 

--- a/packages/components/src/components/accordion/hooks/useAccordionInertContent.ts
+++ b/packages/components/src/components/accordion/hooks/useAccordionInertContent.ts
@@ -1,7 +1,7 @@
 import { type RefObject, useEffect } from 'react';
 
 interface UseAccordionInertContentParamsType {
-  ref: RefObject<HTMLDivElement>;
+  ref: RefObject<HTMLDivElement | null>;
   expanded: boolean;
 }
 

--- a/packages/components/src/components/carousel/__tests__/carousel.test.tsx
+++ b/packages/components/src/components/carousel/__tests__/carousel.test.tsx
@@ -1,12 +1,12 @@
 import { act } from 'react';
+
 import { axe } from 'vitest-axe';
 
 import { render } from '@/lib/tests/render/render';
 
-import type { ICarousel } from '../types/carousel';
-
 import { Carousel } from '../carousel';
 import { useCarousel } from '../hooks/useCarousel';
+import type { ICarousel } from '../types/carousel';
 
 const mockProps: ICarousel = {
   elements: [
@@ -28,7 +28,7 @@ const mockUseCarousel = vi.mocked(useCarousel);
 
 describe('Carousel component', () => {
   it('Should render carousel component', async () => {
-    const { container } = render(<Carousel {...mockProps} ref={() => ({})} />);
+    const { container } = render(<Carousel {...mockProps} ref={() => {}} />);
 
     const results = await axe(container);
     expect(container).toHTMLValidate({
@@ -43,7 +43,7 @@ describe('Carousel component', () => {
     render(
       <Carousel
         {...mockProps}
-        ref={() => ({})}
+        ref={() => {}}
         numElementsPerPage={mockProps.elements.length + 2}
       />,
     );
@@ -59,7 +59,7 @@ describe('Carousel component', () => {
     render(
       <Carousel
         {...mockProps}
-        ref={() => ({})}
+        ref={() => {}}
         allowModifySliceWidth={true}
         numElementsPerPage={0}
       />,
@@ -76,7 +76,7 @@ describe('Carousel component', () => {
     render(
       <Carousel
         {...mockProps}
-        ref={() => ({})}
+        ref={() => {}}
         allowModifySliceWidth={true}
         autoFitContainer={true}
         numElementsPerPage={5}

--- a/packages/components/src/components/carousel/hooks/types/useCarousel.ts
+++ b/packages/components/src/components/carousel/hooks/types/useCarousel.ts
@@ -4,9 +4,9 @@ import type {
 } from '../../types/carousel';
 
 export interface IUseCarouselParams {
-  rootContainerRef: React.RefObject<HTMLDivElement>;
-  viewerContainerRef: React.RefObject<HTMLDivElement>;
-  contentContainerRef: React.RefObject<HTMLDivElement>;
+  rootContainerRef: React.RefObject<HTMLDivElement | null>;
+  viewerContainerRef: React.RefObject<HTMLDivElement | null>;
+  contentContainerRef: React.RefObject<HTMLDivElement | null>;
   circular?: boolean;
   centerMode?: boolean;
   extraPadding?: number;

--- a/packages/components/src/components/carousel/hooks/types/useCarouselKeyNavigation.ts
+++ b/packages/components/src/components/carousel/hooks/types/useCarouselKeyNavigation.ts
@@ -1,5 +1,5 @@
 export interface IUseCarouselKeyNavigationParams {
-  rootContainerRef: React.RefObject<HTMLDivElement>;
+  rootContainerRef: React.RefObject<HTMLDivElement | null>;
   allowShiftRef: React.MutableRefObject<boolean>;
   circular: boolean;
   numPagesRef: React.MutableRefObject<number>;

--- a/packages/components/src/components/carousel/hooks/types/useCarouselSwipe.ts
+++ b/packages/components/src/components/carousel/hooks/types/useCarouselSwipe.ts
@@ -1,6 +1,6 @@
 export interface IUseCarouselSwipeParams {
-  viewerContainerRef: React.RefObject<HTMLDivElement>;
-  contentContainerRef: React.RefObject<HTMLDivElement>;
+  viewerContainerRef: React.RefObject<HTMLDivElement | null>;
+  contentContainerRef: React.RefObject<HTMLDivElement | null>;
   allowShiftRef: React.MutableRefObject<boolean>;
   circular: boolean;
   extraPadding: number;

--- a/packages/components/src/components/carousel/hooks/useCarouselSwipe.ts
+++ b/packages/components/src/components/carousel/hooks/useCarouselSwipe.ts
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useRef } from 'react';
 import { useScrollBlock } from '@/lib/hooks/useScrollBlock/useScrollBlock';
 
 import type { IUseCarouselSwipe } from './types/useCarouselSwipe';
-
 import calcUtils from './utils/calc.utils';
 import CONSTANTS from './utils/constants';
 
@@ -25,7 +24,7 @@ export const useCarouselSwipe: IUseCarouselSwipe = ({
   const isDragging = useRef(false);
   const isHorizontalDragging = useRef(false);
   const isVerticalDragging = useRef(false);
-  const posInitial = useRef<number | undefined>();
+  const posInitial = useRef<number | undefined>(undefined);
   const posX1 = useRef(0);
   const posX2 = useRef(0);
   const posXInitial = useRef(0);

--- a/packages/components/src/components/carousel/types/carousel.ts
+++ b/packages/components/src/components/carousel/types/carousel.ts
@@ -23,8 +23,8 @@ export type CarouselScreenReaderOnlyType = Omit<
 
 export interface ICarouselStandAlone extends DataAttributes {
   cssClasses?: CarouselCssClasses;
-  viewerContainerRef: React.RefObject<HTMLDivElement>;
-  contentContainerRef: React.RefObject<HTMLDivElement>;
+  viewerContainerRef: React.RefObject<HTMLDivElement | null>;
+  contentContainerRef: React.RefObject<HTMLDivElement | null>;
   elements: JSX.Element[];
   screenReaderOnly?: CarouselScreenReaderOnlyType;
   allowModifySliceWidth?: boolean;

--- a/packages/components/src/components/dataTable/hooks/useDataTableHasScroll.ts
+++ b/packages/components/src/components/dataTable/hooks/useDataTableHasScroll.ts
@@ -3,7 +3,7 @@ import { type RefObject, useEffect, useState } from 'react';
 import { hasScroll as checkHasSroll } from '../../../lib/utils/scroll/hasScroll';
 
 interface UseDataTableHasScrollParamsType {
-  ref: RefObject<HTMLDivElement>;
+  ref: RefObject<HTMLDivElement | null>;
 }
 
 interface UseDataTableHasScrollReturnType {

--- a/packages/components/src/components/dataTable/hooks/useDataTableShadow.ts
+++ b/packages/components/src/components/dataTable/hooks/useDataTableShadow.ts
@@ -1,7 +1,7 @@
 import { type RefObject, useEffect } from 'react';
 
 interface UseDataTableShadowParamsType {
-  ref: RefObject<HTMLDivElement>;
+  ref: RefObject<HTMLDivElement | null>;
   headBoxShadow?: string;
   leftBoxShadow?: string;
   rightBoxShadow?: string;

--- a/packages/components/src/components/dataTable/hooks/useDataTableStickyDividers.ts
+++ b/packages/components/src/components/dataTable/hooks/useDataTableStickyDividers.ts
@@ -3,7 +3,7 @@ import { type RefObject, useEffect } from 'react';
 import { hasHorizontalScroll } from '../../../lib/utils/scroll/hasScroll';
 
 interface UseDataTableStickyDividersParamsType {
-  ref: RefObject<HTMLDivElement>;
+  ref: RefObject<HTMLDivElement | null>;
 }
 
 type UseDataTableStickyDividersReturnType = object;

--- a/packages/components/src/components/dataTable/hooks/useDataTableStickyLeftColumns.ts
+++ b/packages/components/src/components/dataTable/hooks/useDataTableStickyLeftColumns.ts
@@ -3,7 +3,7 @@ import { type RefObject, useEffect } from 'react';
 import { hasHorizontalScroll } from '../../../lib/utils/scroll/hasScroll';
 
 interface UseDataTableStickyLeftColumnsParamsType {
-  ref: RefObject<HTMLDivElement>;
+  ref: RefObject<HTMLDivElement | null>;
 }
 
 type UseDataTableStickyLeftColumnsReturnType = object;

--- a/packages/components/src/components/dataTable/hooks/useDataTableStickyRightColumns.ts
+++ b/packages/components/src/components/dataTable/hooks/useDataTableStickyRightColumns.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../lib/utils/scroll/hasScroll';
 
 interface UseDataTableStickyRightColumnsParamsType {
-  ref: RefObject<HTMLDivElement>;
+  ref: RefObject<HTMLDivElement | null>;
 }
 
 type UseDataTableStickyRightColumnsReturnType = object;

--- a/packages/components/src/components/inputSignature/hook/useDraw.tsx
+++ b/packages/components/src/components/inputSignature/hook/useDraw.tsx
@@ -23,8 +23,9 @@ function isImageDataEqual(a: ImageData, b: ImageData) {
 
 export const useDraw = (onChange?: (value: string) => void): ReturnType => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const context =
-    useRef<CanvasRenderingContext2D>() as React.MutableRefObject<CanvasRenderingContext2D>;
+  const context = useRef<CanvasRenderingContext2D | null>(
+    null,
+  ) as React.MutableRefObject<CanvasRenderingContext2D>;
   const isDrawing = useRef<boolean>(false);
   const isFilled = useRef<boolean>(false);
   const signatureStylesRef = useRef<InputSignatureLineStyles>({

--- a/packages/components/src/components/inputSignature/types/inputSignature.ts
+++ b/packages/components/src/components/inputSignature/types/inputSignature.ts
@@ -26,7 +26,7 @@ export interface InputSignatureCustomHandle {
  */
 export interface InputSignatureStandAloneProps extends DataAttributes {
   state: InputSignatureState;
-  canvasRef: React.RefObject<HTMLCanvasElement>;
+  canvasRef: React.RefObject<HTMLCanvasElement | null>;
   placeholder: CommonTextProps;
   errorText?: CommonTextProps;
   onClickContainer: (e: React.MouseEvent<HTMLDivElement>) => void;

--- a/packages/components/src/components/option/option.tsx
+++ b/packages/components/src/components/option/option.tsx
@@ -11,9 +11,8 @@ import {
 import { useClassName } from '@/lib/hooks/useClassName/useClassName';
 import { useGenericComponents } from '@/lib/provider/genericComponentsProvider/genericComponentsProvider';
 
-import type { OptionProps } from './types/option';
-
 import { OptionStandAlone } from './optionStandAlone';
+import type { OptionProps } from './types/option';
 
 /**
  * Option component for rendering selectable list items.
@@ -52,7 +51,7 @@ export const Option = forwardRef(
     });
 
     const { LINK: genericLinkComponent } = useGenericComponents();
-    const innerRef = useRef<HTMLElement>();
+    const innerRef = useRef<HTMLElement | null>(null);
     const [hover, setHover] = useState(false);
     const [focused, setFocused] = useState(false);
 

--- a/packages/components/src/components/popover/__tests__/hooks/usePopoverInteractions.test.ts
+++ b/packages/components/src/components/popover/__tests__/hooks/usePopoverInteractions.test.ts
@@ -19,7 +19,9 @@ vi.mock('@/utils/keyboard/keyboard', () => ({
 const mockOnClose = vi.fn();
 
 // Mock refs for testing
-const createMockRef = <T>(initialValue: T | null = null): RefObject<T> => ({
+const createMockRef = <T>(
+  initialValue: T | null = null,
+): RefObject<T | null> => ({
   current: initialValue,
 });
 

--- a/packages/components/src/components/popover/hooks/types/usePopoverLifecycle.ts
+++ b/packages/components/src/components/popover/hooks/types/usePopoverLifecycle.ts
@@ -12,7 +12,7 @@ interface IUsePopoverLifecycleParams {
 export interface IUsePopoverLifecycleResponse {
   isClosing: boolean;
   isVisible: boolean;
-  popoverRef: React.RefObject<HTMLElement>;
+  popoverRef: React.RefObject<HTMLElement | null>;
   handleInnerRef: (node: HTMLElement | null) => void;
 }
 

--- a/packages/components/src/components/select/types/select.ts
+++ b/packages/components/src/components/select/types/select.ts
@@ -48,13 +48,13 @@ export interface SelectStandAloneProps extends DataAttributes {
   listOptions: SelectListOptionsProps;
   optionSelected?: string;
   onOptionClick: (value: string) => void;
-  listOptionsRef: RefObject<HTMLDivElement>;
+  listOptionsRef: RefObject<HTMLDivElement | null>;
   closePopoverOnScroll?: boolean;
   openAndCloseOnHover?: boolean;
   url?: string;
   urlTarget?: HTMLAttributeAnchorTarget;
   component: 'button' | GenericLinkType;
-  buttonOrLinkRef?: RefObject<HTMLButtonElement>;
+  buttonOrLinkRef?: RefObject<HTMLButtonElement | null>;
   onFocus?: FocusEventHandler<HTMLDivElement>;
   onBlur?: FocusEventHandler<HTMLDivElement>;
   onKeyDown?: KeyboardEventHandler<HTMLDivElement>;

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -12,9 +12,8 @@ import {
 
 import { useClassName } from '@/lib/hooks/useClassName/useClassName';
 
-import type { SliderOffsetBoundariesProps, SliderProps } from './types/slider';
-
 import { SliderStandAlone } from './sliderStandAlone';
+import type { SliderOffsetBoundariesProps, SliderProps } from './types/slider';
 import {
   calcNewValueAfterKeyPress,
   decrementValue,
@@ -121,7 +120,9 @@ export const Slider = forwardRef(
       });
 
     // Debounce callback to avoid calling onChange too many times
-    const timeoutOnChange = useRef<number | NodeJS.Timeout>();
+    const timeoutOnChange = useRef<number | NodeJS.Timeout | undefined>(
+      undefined,
+    );
 
     // Focus the thumb after handleChange to ensure the activePointer is set
     // Also active thumb could change during move in range mode

--- a/packages/components/src/components/slider/types/slider.ts
+++ b/packages/components/src/components/slider/types/slider.ts
@@ -69,7 +69,7 @@ export interface SliderStandAloneProps extends DataAttributes {
   hover: boolean;
   pressed: boolean;
   activePointer: React.MutableRefObject<string>;
-  containerRef: React.RefObject<HTMLDivElement>;
+  containerRef: React.RefObject<HTMLDivElement | null>;
   onMouseDown: React.MouseEventHandler<HTMLDivElement>;
   onChange: (event: MouseEvent | React.TouchEvent | React.MouseEvent) => void;
   onTouchStart: React.TouchEventHandler<HTMLDivElement>;

--- a/packages/components/src/components/table/hooks/useTableHasScroll.ts
+++ b/packages/components/src/components/table/hooks/useTableHasScroll.ts
@@ -3,7 +3,7 @@ import { type RefObject, useEffect, useState } from 'react';
 import { hasScroll as checkHasSroll } from '../../../lib/utils/scroll/hasScroll';
 
 interface UseTableHasScrollParamsType {
-  ref: RefObject<HTMLDivElement>;
+  ref: RefObject<HTMLDivElement | null>;
   disabled?: boolean;
 }
 

--- a/packages/components/src/components/table/hooks/useTableShadow.ts
+++ b/packages/components/src/components/table/hooks/useTableShadow.ts
@@ -1,7 +1,7 @@
 import { type RefObject, useEffect } from 'react';
 
 interface UseTableShadowParamsType {
-  ref: RefObject<HTMLDivElement>;
+  ref: RefObject<HTMLDivElement | null>;
   headBoxShadow?: string;
   leftBoxShadow?: string;
   rightBoxShadow?: string;

--- a/packages/components/src/components/table/hooks/useTableStickyLeftColumns.ts
+++ b/packages/components/src/components/table/hooks/useTableStickyLeftColumns.ts
@@ -3,7 +3,7 @@ import { type RefObject, useEffect } from 'react';
 import { hasHorizontalScroll } from '../../../lib/utils/scroll/hasScroll';
 
 interface UseTableStickyLeftColumnsParamsType {
-  ref: RefObject<HTMLDivElement>;
+  ref: RefObject<HTMLDivElement | null>;
   disabled?: boolean;
 }
 

--- a/packages/components/src/components/table/hooks/useTableStickyRightColumns.ts
+++ b/packages/components/src/components/table/hooks/useTableStickyRightColumns.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../lib/utils/scroll/hasScroll';
 
 interface UseTableStickyRightColumnsParamsType {
-  ref: RefObject<HTMLDivElement>;
+  ref: RefObject<HTMLDivElement | null>;
   disabled?: boolean;
 }
 

--- a/packages/components/src/components/tabs/__tests__/tabs.test.tsx
+++ b/packages/components/src/components/tabs/__tests__/tabs.test.tsx
@@ -8,11 +8,10 @@ import { render } from '@/lib/tests/render/render';
 import { windowMatchMedia } from '@/lib/tests/windowMatchMedia/windowMatchMedia';
 import { DEVICE_BREAKPOINTS } from '@/lib/types/breakpoints/breakpoints';
 
-import type { TabsUnControlledProps } from '../types/tabs';
-
 import * as UseTabsUtils from '../hooks/useTabs/useTabs';
 import { TabsControlled } from '../tabsControlled';
 import { TabsUnControlled } from '../tabsUnControlled';
+import type { TabsUnControlledProps } from '../types/tabs';
 
 const tabs = [
   { content: 'Tab 1' },
@@ -129,7 +128,7 @@ describe('Tabs component', () => {
         focus: 0,
         handleClickIcon: () => ({}),
         handleClickTab: () => ({}),
-        listEl: { current: null } as RefObject<HTMLLIElement>,
+        listEl: { current: null } as unknown as RefObject<HTMLLIElement>,
         position: 0,
       };
     });

--- a/packages/components/src/components/tabs/hooks/useTabs/useTabs.tsx
+++ b/packages/components/src/components/tabs/hooks/useTabs/useTabs.tsx
@@ -17,7 +17,7 @@ interface ReturnType {
   handleClickIcon: (isNextPosition: boolean) => void;
   focus: number;
   handleClickTab: (newFocus: number) => void;
-  listEl: React.RefObject<HTMLElement>;
+  listEl: React.RefObject<HTMLElement | null>;
 }
 
 /**

--- a/packages/components/src/components/toggle/utils/thumbTransformCalculations.ts
+++ b/packages/components/src/components/toggle/utils/thumbTransformCalculations.ts
@@ -33,9 +33,9 @@ interface UseToggleTransformProps {
   /** Current toggle state (true = ON, false = OFF) */
   checked: boolean;
   /** Ref to the track element (component controlled) */
-  trackRef: React.RefObject<HTMLButtonElement>;
+  trackRef: React.RefObject<HTMLButtonElement | null>;
   /** Ref to the thumb element (component controlled) */
-  thumbRef: React.RefObject<HTMLDivElement>;
+  thumbRef: React.RefObject<HTMLDivElement | null>;
 }
 
 /**

--- a/packages/components/src/components/tooltip/hooks/useTooltip.ts
+++ b/packages/components/src/components/tooltip/hooks/useTooltip.ts
@@ -1,4 +1,3 @@
-import { type Coords, arrow, flip, shift } from '@floating-ui/dom';
 import {
   type MutableRefObject,
   type RefObject,
@@ -8,6 +7,8 @@ import {
   useState,
 } from 'react';
 
+import { type Coords, arrow, flip, shift } from '@floating-ui/dom';
+
 import { useClassName } from '@/lib/hooks/useClassName/useClassName';
 import { useClickOutside } from '@/lib/hooks/useClickOutside/useClickOutside';
 import { useEscPressed } from '@/lib/hooks/useEscPressed/useEscPressed';
@@ -15,15 +16,14 @@ import { useActiveBreakpoints } from '@/lib/hooks/useMediaDevice/useActiveBreakp
 import { DEVICE_BREAKPOINTS } from '@/lib/types/breakpoints/breakpoints';
 import { POSITIONS } from '@/lib/types/positions/positions';
 
+import { focusElementOrFirstDescendant } from '../../../lib/utils/focusHandlers/focusHandlers';
+import { computePosition } from '../positioning/computePosition';
 import type { TooltipCssClasses } from '../types/tooltip';
 import type { TooltipAlignType } from '../types/tooltipAlign';
 
-import { focusElementOrFirstDescendant } from '../../../lib/utils/focusHandlers/focusHandlers';
-import { computePosition } from '../positioning/computePosition';
-
 interface UseTooltipType<Variant> {
-  labelRef: RefObject<HTMLDivElement>;
-  tooltipRef: RefObject<HTMLDivElement>;
+  labelRef: RefObject<HTMLDivElement | null>;
+  tooltipRef: RefObject<HTMLDivElement | null>;
   variant?: Variant;
   onOpenClose?: (open: boolean) => void;
   align?: `${TooltipAlignType}` | string;

--- a/packages/components/src/components/tooltip/hooks/useTooltipAsModalAriaLabel.ts
+++ b/packages/components/src/components/tooltip/hooks/useTooltipAsModalAriaLabel.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 export const useTooltipAsModalAriaLabel = (
-  ref: React.RefObject<HTMLDivElement>,
+  ref: React.RefObject<HTMLDivElement | null>,
 ): string | undefined => {
   const [ariaLabel, setArialabel] = useState<string | undefined>(undefined);
 

--- a/packages/components/src/components/tooltip/hooks/useTooltipContentScroll.ts
+++ b/packages/components/src/components/tooltip/hooks/useTooltipContentScroll.ts
@@ -3,7 +3,7 @@ import { type RefObject, useCallback, useRef, useState } from 'react';
 import { hasScroll as checkHasScroll } from '../../../lib/utils/scroll/hasScroll';
 
 interface UseTooltipContentScrollParamsType {
-  tooltipRef: RefObject<HTMLDivElement>;
+  tooltipRef: RefObject<HTMLDivElement | null>;
 }
 
 interface UseTooltipContentScrollReturnType {
@@ -21,7 +21,7 @@ export const useTooltipContentScroll = ({
   tooltipRef,
 }: UseTooltipContentScrollParamsType): UseTooltipContentScrollReturnType => {
   const [contentHasScroll, setContentHasScroll] = useState(false);
-  const resizeObserverRef = useRef<ResizeObserver>();
+  const resizeObserverRef = useRef<ResizeObserver | undefined>(undefined);
 
   const contentRefHandler = useCallback(
     (innerContentElement: HTMLDivElement | null) => {

--- a/packages/components/src/lib/hooks/useContentVisibility/useContentVisibility.ts
+++ b/packages/components/src/lib/hooks/useContentVisibility/useContentVisibility.ts
@@ -5,7 +5,6 @@ import type {
   UseContentVisibilityParamsType,
   UseContentVisibilityReturnType,
 } from './types/useContentVisibility';
-
 import { isContentVisibleEnough } from './utils/contentVisibility';
 
 /**
@@ -68,8 +67,12 @@ export const useContentVisibility = ({
 }: UseContentVisibilityParamsType): UseContentVisibilityReturnType => {
   const containerRef = useRef<HTMLElement | null | undefined>(null);
   const contentRef = useRef<HTMLElement | null | undefined>(null);
-  const resizeContentObserverRef = useRef<ResizeObserver>();
-  const resizeContainerObserverRef = useRef<ResizeObserver>();
+  const resizeContentObserverRef = useRef<ResizeObserver | undefined>(
+    undefined,
+  );
+  const resizeContainerObserverRef = useRef<ResizeObserver | undefined>(
+    undefined,
+  );
   const isContentVisibleRef = useRef<boolean | undefined>(undefined);
 
   const handleContentVisible = useCallback(() => {

--- a/packages/components/src/lib/hooks/useEscPressed/types/useEscPressed.ts
+++ b/packages/components/src/lib/hooks/useEscPressed/types/useEscPressed.ts
@@ -1,5 +1,5 @@
 export interface useEscPressedParamsType {
-  ref: React.RefObject<HTMLElement>;
+  ref: React.RefObject<HTMLElement | null>;
   onEscPress: (event: KeyboardEvent) => void;
   disablePreventDefault?: boolean;
   disableStopPropagation?: boolean;

--- a/packages/components/src/lib/hooks/useRoveFocus/useRoveFocus.ts
+++ b/packages/components/src/lib/hooks/useRoveFocus/useRoveFocus.ts
@@ -42,7 +42,7 @@ import type { UseRoveFocusProps } from './types/useRoveFocus';
  *        The movement logic for the "Page Up" key. Can be a number or a custom function.
  * @param {number} props.size - The total number of focusable elements in the list.
  *
- * @returns {[number, Dispatch<SetStateAction<number>>, React.RefObject<HTMLElement>]}
+ * @returns {[number, Dispatch<SetStateAction<number>>, React.RefObject<HTMLElement | null>]}
  *          A tuple containing:
  *          - `currentFocus`: The index of the currently focused element.
  *          - `setCurrentFocus`: A state setter function to manually update the focused index.
@@ -68,10 +68,10 @@ export const useRoveFocus = ({
 }: UseRoveFocusProps): [
   number,
   Dispatch<SetStateAction<number>>,
-  React.RefObject<HTMLElement>,
+  React.RefObject<HTMLElement | null>,
 ] => {
   const [currentFocus, setCurrentFocus] = useState(currentFocusSelected);
-  const listEl = useRef<HTMLElement>(null);
+  const listEl = useRef<HTMLElement | null>(null);
 
   const moveDown = (e: KeyboardEvent) => {
     if (keyDownMove !== null) {

--- a/packages/components/src/lib/hooks/useScrollDetection/useScrollDetection.ts
+++ b/packages/components/src/lib/hooks/useScrollDetection/useScrollDetection.ts
@@ -43,7 +43,7 @@ export const useScrollDetection = ({
   autoFocus = false,
 }: UseScrollDetectionParamsType = {}): UseScrollDetectionReturnType => {
   const [hasScroll, setHasScroll] = useState(false);
-  const resizeObserverRef = useRef<ResizeObserver>();
+  const resizeObserverRef = useRef<ResizeObserver | undefined>(undefined);
   const hasFocusedRef = useRef(false);
 
   /**

--- a/packages/components/src/lib/types/react.d.ts
+++ b/packages/components/src/lib/types/react.d.ts
@@ -1,0 +1,22 @@
+/**
+ * Global type declarations for React 19 compatibility
+ *
+ * React 19 moved the JSX namespace to React.JSX
+ * This file re-exports it to maintain backward compatibility
+ * with existing code that uses JSX.Element
+ */
+import type React from 'react';
+
+declare global {
+  namespace JSX {
+    type Element = React.JSX.Element;
+    type ElementType = React.JSX.ElementType;
+    type IntrinsicElements = React.JSX.IntrinsicElements;
+    type LibraryManagedAttributes<C, P> = React.JSX.LibraryManagedAttributes<
+      C,
+      P
+    >;
+  }
+}
+
+export {};

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -22,8 +22,8 @@
   "dependencies": {
     "@kubit-ui-web/design-system": "workspace:*",
     "@kubit-ui-web/react-components": "workspace:*",
-    "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
   },
   "devDependencies": {
     "@figma/code-connect": "^1.3.13",
@@ -35,8 +35,8 @@
     "@storybook/react-vite": "^10.2.8",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@types/node": "^25.2.3",
-    "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.4",
     "eslint": "^10.0.0",
     "eslint-config-kubit": "2.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  eslint-plugin-react-hooks: 7.1.0-canary-272441a9-20260209
+  zod-validation-error: ^3.4.0
+
 importers:
 
   .:
@@ -12,8 +16,8 @@ importers:
         specifier: ^2.29.8
         version: 2.29.8(@types/node@25.2.3)
       turbo:
-        specifier: ^2.8.1
-        version: 2.8.1
+        specifier: ^2.8.7
+        version: 2.8.7
 
   packages/components:
     dependencies:
@@ -32,7 +36,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -43,11 +47,11 @@ importers:
         specifier: ^25.2.3
         version: 25.2.3
       '@types/react':
-        specifier: ^18.3.12
-        version: 18.3.27
+        specifier: ^19.2.14
+        version: 19.2.14
       '@types/react-dom':
-        specifier: ^18.3.1
-        version: 18.3.7(@types/react@18.3.27)
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
       '@types/testing-library__jest-dom':
         specifier: ^6.0.0
         version: 6.0.0
@@ -82,11 +86,11 @@ importers:
         specifier: ^3.8.1
         version: 3.8.1
       react:
-        specifier: 18.3.1
-        version: 18.3.1
+        specifier: ^19.2.4
+        version: 19.2.4
       react-dom:
-        specifier: 18.3.1
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -161,33 +165,33 @@ importers:
         specifier: workspace:*
         version: link:../components
       react:
-        specifier: 18.3.1
-        version: 18.3.1
+        specifier: ^19.2.4
+        version: 19.2.4
       react-dom:
-        specifier: 18.3.1
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
     devDependencies:
       '@figma/code-connect':
         specifier: ^1.3.13
         version: 1.3.13
       '@storybook/addon-a11y':
         specifier: ^10.2.8
-        version: 10.2.8(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 10.2.8(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/addon-coverage':
         specifier: ^3.0.0
         version: 3.0.0(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))
       '@storybook/addon-docs':
         specifier: ^10.2.8
-        version: 10.2.8(@types/react@18.3.27)(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))
+        version: 10.2.8(@types/react@19.2.14)(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))
       '@storybook/addon-links':
         specifier: ^10.2.8
-        version: 10.2.8(react@18.3.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 10.2.8(react@19.2.4)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/react':
         specifier: ^10.2.8
-        version: 10.2.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        version: 10.2.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: ^10.2.8
-        version: 10.2.8(esbuild@0.27.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.55.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))
+        version: 10.2.8(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.55.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^6.0.2
         version: 6.0.2(prettier@3.8.1)
@@ -195,11 +199,11 @@ importers:
         specifier: ^25.2.3
         version: 25.2.3
       '@types/react':
-        specifier: ^18.3.12
-        version: 18.3.27
+        specifier: ^19.2.14
+        version: 19.2.14
       '@types/react-dom':
-        specifier: ^18.3.1
-        version: 18.3.7(@types/react@18.3.27)
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.1.4
         version: 5.1.4(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))
@@ -211,7 +215,7 @@ importers:
         version: 2.0.2(eslint@10.0.0)(prettier@3.8.1)(typescript@5.9.3)
       eslint-plugin-storybook:
         specifier: 10.2.8
-        version: 10.2.8(eslint@10.0.0)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        version: 10.2.8(eslint@10.0.0)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       html-validate:
         specifier: ^10.7.0
         version: 10.7.0(vitest@4.0.18)
@@ -223,13 +227,13 @@ importers:
         version: 1.30.0
       storybook:
         specifier: ^10.2.8
-        version: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook-addon-deep-controls:
         specifier: ^0.10.0
-        version: 0.10.0(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 0.10.0(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       storybook-addon-pseudo-states:
         specifier: ^10.2.8
-        version: 10.2.8(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 10.2.8(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1565,21 +1569,25 @@ packages:
     resolution: {integrity: sha512-otVbS4zeo3n71zgGLBYRTriDzc0zpruC0WI3ICwjpIk454cLwGV0yzh4jlGYWQJYJk0BRAmXFd3ooKIF+bKBHw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@1.12.0':
     resolution: {integrity: sha512-IStQDjIT7Lzmqg1i9wXvPL/NsYsxF24WqaQFS8b8rxra+z0VG7saBOsEnOaa4jcEY8MVpLYabFhTV+fSsA2vnA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-x64-gnu@1.12.0':
     resolution: {integrity: sha512-SipT7EVORz8pOQSFwemOm91TpSiBAGmOjG830/o+aLEsvQ4pEy223+SAnCfITh7+AahldYsJnVoIs519jmIlKQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@1.12.0':
     resolution: {integrity: sha512-mGh0XfUzKdn+WFaqPacziNraCWL5znkHRfQVxG9avGS9zb2KC/N1EBbPzFqutDwixGDP54r2gx4q54YCJEZ4iQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-wasm32-wasi@1.12.0':
     resolution: {integrity: sha512-SZN6v7apKmQf/Vwiqb6e/s3Y2Oacw8uW8V2i1AlxtyaEFvnFE0UBn89zq6swEwE3OCajNWs0yPvgAXUMddYc7Q==}
@@ -1638,24 +1646,28 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.1':
     resolution: {integrity: sha512-UvApLEGholmxw/HIwmUnLq3CwdydbhaHHllvWiCTNbyGom7wTwOtz5OAQbAKZYyiEOeIXZNPkM7nA4Dtng7CLw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.1':
     resolution: {integrity: sha512-uVctNgZHiGnJx5Fij7wHLhgw4uyZBVi6mykeWKOqE7bVy9Hcxn0fM/IuqdMwk6hXlaf9fFShDTFz2+YejP+x0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.1':
     resolution: {integrity: sha512-T6Eg0xWwcxd/MzBcuv4Z37YVbUbJxy5cMNnbIt/Yr99wFwli30O4BPlY8hKeGyn6lWNtU0QioBS46lVzDN38bg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.1':
     resolution: {integrity: sha512-PuGZVS2xNJyLADeh2F04b+Cz4NwvpglbtWACgrDOa5YDTEHKwmiTDjoD5eZ9/ptXtcpeFrMqD2H4Zn33KAh1Eg==}
@@ -1729,66 +1741,79 @@ packages:
     resolution: {integrity: sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.55.1':
     resolution: {integrity: sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.55.1':
     resolution: {integrity: sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.55.1':
     resolution: {integrity: sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.55.1':
     resolution: {integrity: sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.55.1':
     resolution: {integrity: sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.55.1':
     resolution: {integrity: sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.55.1':
     resolution: {integrity: sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.55.1':
     resolution: {integrity: sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.55.1':
     resolution: {integrity: sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.55.1':
     resolution: {integrity: sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.55.1':
     resolution: {integrity: sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.55.1':
     resolution: {integrity: sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.55.1':
     resolution: {integrity: sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==}
@@ -2060,16 +2085,13 @@ packages:
   '@types/node@25.2.3':
     resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
 
-  '@types/prop-types@15.7.15':
-    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
-
-  '@types/react-dom@18.3.7':
-    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
-      '@types/react': ^18.0.0
+      '@types/react': ^19.2.0
 
-  '@types/react@18.3.27':
-    resolution: {integrity: sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==}
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
@@ -2182,41 +2204,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3068,24 +3098,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   eslint-barrel-file-utils-linux-arm64-musl@0.0.11:
     resolution: {integrity: sha512-p3dftf3t+YzfVVsO7jbjdbZHluX+B1JijYZLssSSqJfS2rliNmaCW1vdU+V9gJVy+wjEPlVENpKYEDBWqUWG3w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   eslint-barrel-file-utils-linux-x64-gnu@0.0.11:
     resolution: {integrity: sha512-Yhok34OIE2fXIwV8+2sRySwiD4i/XRFXLbTS9objm6zr5BKZzVUeGOiiNuggZthgOn+eyV6t2oQw8PDoipuEJA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   eslint-barrel-file-utils-linux-x64-musl@0.0.11:
     resolution: {integrity: sha512-wpRUbOjMex3E9uxkGCn1JGiGZECLYqzAr3jWBP1jsDbB3yf9ebpFTJSG1635PJnwh0ECIoPtQcgn+cAqQDQqpQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   eslint-barrel-file-utils-win32-arm64-msvc@0.0.11:
     resolution: {integrity: sha512-/bjKmAMIUrw6EoCiyQXp6CDNh9GUAKjprjDIeCkG5EPuxaHveriCwNm94PelE+9WrnjqSaChxzBBpiss8fUxpQ==}
@@ -3181,6 +3215,7 @@ packages:
     resolution: {integrity: sha512-/baBXDqkfW8x0UlqfYAfRCkmVWiH8qFZ4uhT6yLVBLssiypDTbe78W6lNBse7huBFv1ipR5PG9evkxEnIXDxjA==}
     peerDependencies:
       eslint: '>= 5'
+    bundledDependencies: []
 
   eslint-plugin-compat@6.1.0:
     resolution: {integrity: sha512-xiwHz7mj6+Zj7NWOO/uaWdrQ6zP0zL5CPyKVCNlB4JaoUFeYPYwejf5toqyHGlXzhuPUdCpg31uBRiWqcgiS0A==}
@@ -3258,8 +3293,8 @@ packages:
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
 
-  eslint-plugin-react-hooks@7.0.1:
-    resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
+  eslint-plugin-react-hooks@7.1.0-canary-272441a9-20260209:
+    resolution: {integrity: sha512-9ySbj7lQGI5y3dmRwwzs4ozxNGCATM++72dNOnEtoFaipk9hup+KbEI9WTrTKQaMogVN8y6Krlwtfz71GhFSWQ==}
     engines: {node: '>=18'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
@@ -4025,24 +4060,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -4826,10 +4865,10 @@ packages:
     resolution: {integrity: sha512-+NRMYs2DyTP4/tqWz371Oo50JqmWltR1h2gcdgUMAWZJIAvrd0/SqlCfx7tpzpl/s36rzw6qH2MjoNrxtRNYhA==}
     engines: {node: ^20.9.0 || >=22}
 
-  react-dom@18.3.1:
-    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+  react-dom@19.2.4:
+    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
-      react: ^18.3.1
+      react: ^19.2.4
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -4841,8 +4880,8 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
-  react@18.3.1:
-    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+  react@19.2.4:
+    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
@@ -4971,8 +5010,8 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
-  scheduler@0.23.2:
-    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   schema-utils@2.7.1:
     resolution: {integrity: sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==}
@@ -5322,38 +5361,38 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  turbo-darwin-64@2.8.1:
-    resolution: {integrity: sha512-FQ6Uqxty/H1Nvn1dpBe8KUlMRclTuiyNSc1PCeDL/ad7M9ykpWutB51YpMpf9ibTA32M6wLdIRf+D96W6hDAtQ==}
+  turbo-darwin-64@2.8.7:
+    resolution: {integrity: sha512-Xr4TO/oDDwoozbDtBvunb66g//WK8uHRygl72vUthuwzmiw48pil4IuoG/QbMHd9RE8aBnVmzC0WZEWk/WWt3A==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.8.1:
-    resolution: {integrity: sha512-4bCcEpGP2/aSXmeN2gl5SuAmS1q5ykjubnFvSoXjQoCKtDOV+vc4CTl/DduZzUUutCVUWXjl8OyfIQ+DGCaV4A==}
+  turbo-darwin-arm64@2.8.7:
+    resolution: {integrity: sha512-p8Xbmb9kZEY/NoshQUcFmQdO80s2PCGoLYj5DbpxjZr3diknipXxzOK7pcmT7l2gNHaMCpFVWLkiFY9nO3EU5w==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.8.1:
-    resolution: {integrity: sha512-m99JRlWlEgXPR7mkThAbKh6jbTmWSOXM/c6rt8yd4Uxh0+wjq7+DYcQbead6aoOqmCP9akswZ8EXIv1ogKBblg==}
+  turbo-linux-64@2.8.7:
+    resolution: {integrity: sha512-nwfEPAH3m5y/nJeYly3j1YJNYU2EG5+2ysZUxvBNM+VBV2LjQaLxB9CsEIpIOKuWKCjnFHKIADTSDPZ3D12J5Q==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.8.1:
-    resolution: {integrity: sha512-AsPlza3AsavJdl2o7FE67qyv0aLfmT1XwFQGzvwpoAO6Bj7S4a03tpUchZKNuGjNAkKVProQRFnB7PgUAScFXA==}
+  turbo-linux-arm64@2.8.7:
+    resolution: {integrity: sha512-mgA/M6xiJzyxtXV70TtWGDPh+I6acOKmeQGtOzbFQZYEf794pu5jax26bCk5skAp1gqZu3vacPr6jhYHoHU9IQ==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.8.1:
-    resolution: {integrity: sha512-GdqNO6bYShRsr79B+2G/2ssjLEp9uBTvLBJSWRtRCiac/SEmv8T6RYv9hu+h5oGbFALtnKNp6BQBw78RJURsPw==}
+  turbo-windows-64@2.8.7:
+    resolution: {integrity: sha512-sHTYMaXuCcyHnGUQgfUUt7S8407TWoP14zc/4N2tsM0wZNK6V9h4H2t5jQPtqKEb6Fg8313kygdDgEwuM4vsHg==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.8.1:
-    resolution: {integrity: sha512-n40E6IpkzrShRo3yMdRpgnn1/sAbGC6tZXwyNu8fe9RsufeD7KBiaoRSvw8xLyqV3pd2yoTL2rdCXq24MnTCWA==}
+  turbo-windows-arm64@2.8.7:
+    resolution: {integrity: sha512-WyGiOI2Zp3AhuzVagzQN+T+iq0fWx0oGxDfAWT3ZiLEd4U0cDUkwUZDKVGb3rKqPjDL6lWnuxKKu73ge5xtovQ==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.8.1:
-    resolution: {integrity: sha512-pbSMlRflA0RAuk/0jnAt8pzOYh1+sKaT8nVtcs75OFGVWD0evleQRmKtHJJV42QOhaC3Hx9mUUSOom/irasbjA==}
+  turbo@2.8.7:
+    resolution: {integrity: sha512-RBLh5caMAu1kFdTK1jgH2gH/z+jFsvX5rGbhgJ9nlIAWXSvxlzwId05uDlBA1+pBd3wO/UaKYzaQZQBXDd7kcA==}
     hasBin: true
 
   type-check@0.4.0:
@@ -7264,11 +7303,11 @@ snapshots:
 
   '@mdn/browser-compat-data@6.1.5': {}
 
-  '@mdx-js/react@3.1.1(@types/react@18.3.27)(react@18.3.1)':
+  '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@types/mdx': 2.0.13
-      '@types/react': 18.3.27
-      react: 18.3.1
+      '@types/react': 19.2.14
+      react: 19.2.4
 
   '@microsoft/api-extractor-model@7.32.2(@types/node@25.2.3)':
     dependencies:
@@ -7551,11 +7590,11 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-a11y@10.2.8(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-a11y@10.2.8(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.1
-      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   '@storybook/addon-coverage@3.0.0(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))':
     dependencies:
@@ -7571,15 +7610,15 @@ snapshots:
       - supports-color
       - vite
 
-  '@storybook/addon-docs@10.2.8(@types/react@18.3.27)(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))':
+  '@storybook/addon-docs@10.2.8(@types/react@19.2.14)(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))':
     dependencies:
-      '@mdx-js/react': 3.1.1(@types/react@18.3.27)(react@18.3.1)
-      '@storybook/csf-plugin': 10.2.8(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))
-      '@storybook/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/react-dom-shim': 10.2.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@storybook/csf-plugin': 10.2.8(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))
+      '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@storybook/react-dom-shim': 10.2.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -7588,17 +7627,17 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-links@10.2.8(react@18.3.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-links@10.2.8(react@19.2.4)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     optionalDependencies:
-      react: 18.3.1
+      react: 19.2.4
 
-  '@storybook/builder-vite@10.2.8(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))':
+  '@storybook/builder-vite@10.2.8(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))':
     dependencies:
-      '@storybook/csf-plugin': 10.2.8(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))
-      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/csf-plugin': 10.2.8(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))
+      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
       vite: 8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0)
     transitivePeerDependencies:
@@ -7606,9 +7645,9 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.2.8(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))':
+  '@storybook/csf-plugin@10.2.8(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))':
     dependencies:
-      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.2
@@ -7617,30 +7656,30 @@ snapshots:
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/icons@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@storybook/icons@2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/react-dom-shim@10.2.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/react-dom-shim@10.2.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/react-vite@10.2.8(esbuild@0.27.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.55.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))':
+  '@storybook/react-vite@10.2.8(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.55.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.3(typescript@5.9.3)(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.55.1)
-      '@storybook/builder-vite': 10.2.8(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))
-      '@storybook/react': 10.2.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+      '@storybook/builder-vite': 10.2.8(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0))
+      '@storybook/react': 10.2.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
-      react: 18.3.1
+      react: 19.2.4
       react-docgen: 8.0.2
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 19.2.4(react@19.2.4)
       resolve: 1.22.11
-      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tsconfig-paths: 4.2.0
       vite: 8.0.0-beta.10(@types/node@25.2.3)(esbuild@0.27.2)(terser@5.46.0)
     transitivePeerDependencies:
@@ -7650,14 +7689,14 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.2.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
+  '@storybook/react@10.2.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.2.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      react: 18.3.1
+      '@storybook/react-dom-shim': 10.2.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      react: 19.2.4
       react-docgen: 8.0.2
-      react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 19.2.4(react@19.2.4)
+      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -7683,15 +7722,15 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@testing-library/dom': 10.4.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 18.3.27
-      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
@@ -7782,15 +7821,12 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/prop-types@15.7.15': {}
-
-  '@types/react-dom@18.3.7(@types/react@18.3.27)':
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
-      '@types/react': 18.3.27
+      '@types/react': 19.2.14
 
-  '@types/react@18.3.27':
+  '@types/react@19.2.14':
     dependencies:
-      '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
   '@types/resolve@1.20.6': {}
@@ -9011,7 +9047,7 @@ snapshots:
       eslint-plugin-prettier: 5.5.5(eslint-config-prettier@10.1.8(eslint@10.0.0))(eslint@10.0.0)(prettier@3.8.1)
       eslint-plugin-promise: 7.2.1(eslint@10.0.0)
       eslint-plugin-react: 7.37.5(eslint@10.0.0)
-      eslint-plugin-react-hooks: 7.0.1(eslint@10.0.0)
+      eslint-plugin-react-hooks: 7.1.0-canary-272441a9-20260209(eslint@10.0.0)
       eslint-plugin-react-refresh: 0.5.0(eslint@10.0.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@10.0.0)
       eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@10.0.0)(typescript@5.9.3))(eslint@10.0.0)(typescript@5.9.3))(eslint@10.0.0)
@@ -9192,7 +9228,7 @@ snapshots:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0)
       eslint: 10.0.0
 
-  eslint-plugin-react-hooks@7.0.1(eslint@10.0.0):
+  eslint-plugin-react-hooks@7.1.0-canary-272441a9-20260209(eslint@10.0.0):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.0
@@ -9233,11 +9269,11 @@ snapshots:
     dependencies:
       eslint: 10.0.0
 
-  eslint-plugin-storybook@10.2.8(eslint@10.0.0)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3):
+  eslint-plugin-storybook@10.2.8(eslint@10.0.0)(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.55.0(eslint@10.0.0)(typescript@5.9.3)
       eslint: 10.0.0
-      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10874,11 +10910,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-dom@18.3.1(react@18.3.1):
+  react-dom@19.2.4(react@19.2.4):
     dependencies:
-      loose-envify: 1.4.0
-      react: 18.3.1
-      scheduler: 0.23.2
+      react: 19.2.4
+      scheduler: 0.27.0
 
   react-is@16.13.1: {}
 
@@ -10886,9 +10921,7 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
-  react@18.3.1:
-    dependencies:
-      loose-envify: 1.4.0
+  react@19.2.4: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -11078,9 +11111,7 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
-  scheduler@0.23.2:
-    dependencies:
-      loose-envify: 1.4.0
+  scheduler@0.27.0: {}
 
   schema-utils@2.7.1:
     dependencies:
@@ -11199,18 +11230,18 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook-addon-deep-controls@0.10.0(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  storybook-addon-deep-controls@0.10.0(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
-      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  storybook-addon-pseudo-states@10.2.8(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  storybook-addon-pseudo-states@10.2.8(storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
-      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  storybook@10.2.8(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
@@ -11219,7 +11250,7 @@ snapshots:
       open: 10.2.0
       recast: 0.23.11
       semver: 7.7.3
-      use-sync-external-store: 1.6.0(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@19.2.4)
       ws: 8.19.0
     optionalDependencies:
       prettier: 3.8.1
@@ -11469,32 +11500,32 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  turbo-darwin-64@2.8.1:
+  turbo-darwin-64@2.8.7:
     optional: true
 
-  turbo-darwin-arm64@2.8.1:
+  turbo-darwin-arm64@2.8.7:
     optional: true
 
-  turbo-linux-64@2.8.1:
+  turbo-linux-64@2.8.7:
     optional: true
 
-  turbo-linux-arm64@2.8.1:
+  turbo-linux-arm64@2.8.7:
     optional: true
 
-  turbo-windows-64@2.8.1:
+  turbo-windows-64@2.8.7:
     optional: true
 
-  turbo-windows-arm64@2.8.1:
+  turbo-windows-arm64@2.8.7:
     optional: true
 
-  turbo@2.8.1:
+  turbo@2.8.7:
     optionalDependencies:
-      turbo-darwin-64: 2.8.1
-      turbo-darwin-arm64: 2.8.1
-      turbo-linux-64: 2.8.1
-      turbo-linux-arm64: 2.8.1
-      turbo-windows-64: 2.8.1
-      turbo-windows-arm64: 2.8.1
+      turbo-darwin-64: 2.8.7
+      turbo-darwin-arm64: 2.8.7
+      turbo-linux-64: 2.8.7
+      turbo-linux-arm64: 2.8.7
+      turbo-windows-64: 2.8.7
+      turbo-windows-arm64: 2.8.7
 
   type-check@0.4.0:
     dependencies:
@@ -11631,9 +11662,9 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
-  use-sync-external-store@1.6.0(react@18.3.1):
+  use-sync-external-store@1.6.0(react@19.2.4):
     dependencies:
-      react: 18.3.1
+      react: 19.2.4
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
- Update peerDependencies to support React 18.3.0 || 19.0.0
- Upgrade devDependencies to React 19.2.4 and @types/react 19.2.14
- Add global JSX namespace declaration for React 19 compatibility
- Fix 30+ files with RefObject<T | null> types for React 19 stricter typing
- Add explicit initial values to useRef() calls (React 19 requirement)
- Fix 6 test errors related to ref callbacks and mock RefObjects
- Add pnpm overrides for eslint-plugin-react-hooks canary version (ESLint 10 compatibility)
- Add zod-validation-error override to resolve ESLint 10 package exports issue

Affected packages:
- @kubit-ui-web/react-components
- @kubit-ui-web/design-system (types only)
- @kubit-ui-web/storybook

TypeScript errors: 56 → 0 ✅

The library maintains full compatibility with React 18.3+ while supporting React 19. No React 19 exclusive features are used to preserve backward compatibility.