### PR TITLE
feat: add React 19 support with backward compatibility for React 18.3+

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "url": "git+https://github.com/kubit-ui/kubit-react-components.git",
     "directory": "."
   },
-  "license": "Apache-2.0",
   "engines": {
     "node": "22.x"
   },
+  "license": "Apache-2.0",
   "packageManager": "pnpm@10.29.3",
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
- Update peerDependencies to support React 18.3.0 or React 19.0.0
- Upgrade devDependencies to React 19.2.4 and @types/react 19.2.14
- Add global JSX namespace declaration for React 19 compatibility
- Fix 30+ files with RefObject<T | null> types for React 19 stricter typing
- Add explicit initial values to useRef() calls (React 19 requirement)
- Fix 6 test errors related to ref callbacks and mock RefObjects
- Add pnpm overrides for eslint-plugin-react-hooks canary version (ESLint 10 compatibility)
- Add zod-validation-error override to resolve ESLint 10 package exports issue

Affected packages:
- @kubit-ui-web/react-components
- @kubit-ui-web/design-system (types only)
- @kubit-ui-web/storybook

TypeScript errors: 56 → 0 ✅

The library maintains full compatibility with React 18.3+ while supporting React 19. No React 19 exclusive features are used to preserve backward compatibility.